### PR TITLE
CDAP-15839 Failpipeline-sink plugin validation - package rename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   </issueManagement>
   <properties>
     <main.basedir>${project.basedir}</main.basedir>
-    <cdap.version>6.0.0-SNAPSHOT</cdap.version>
+    <cdap.version>6.1.0-SNAPSHOT</cdap.version>
     <hadoop.version>2.3.0</hadoop.version>
     <hydrator.version>2.2.0-SNAPSHOT</hydrator.version>
     <guava.version>13.0.1</guava.version>
@@ -266,7 +266,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <_exportcontents>io.cdap.plugin.batch.*</_exportcontents>
+            <_exportcontents>io.cdap.plugin.failpipeline.*</_exportcontents>
             <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
             <Embed-Transitive>true</Embed-Transitive>
             <Embed-Directory>lib</Embed-Directory>
@@ -288,8 +288,8 @@
         <version>1.1.0</version>
         <configuration>
           <cdapArtifacts>
-            <parent>system:cdap-data-pipeline[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
-            <parent>system:cdap-data-streams[6.0.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-pipeline[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
+            <parent>system:cdap-data-streams[6.1.0-SNAPSHOT,7.0.0-SNAPSHOT)</parent>
           </cdapArtifacts>
         </configuration>
         <executions>

--- a/src/main/java/io/cdap/plugin/failpipeline/sink/FailPipelineSink.java
+++ b/src/main/java/io/cdap/plugin/failpipeline/sink/FailPipelineSink.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch.sink;
+package io.cdap.plugin.failpipeline.sink;
 
 import io.cdap.cdap.api.annotation.Description;
 import io.cdap.cdap.api.annotation.Name;

--- a/src/test/java/io/cdap/plugin/failpipeline/sink/FailPipelineSinkTest.java
+++ b/src/test/java/io/cdap/plugin/failpipeline/sink/FailPipelineSinkTest.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.plugin.batch.sink;
+package io.cdap.plugin.failpipeline.sink;
 
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
JIRA: https://issues.cask.co/browse/CDAP-15839

In scope of this PR:
- migrated to CDAP core 6.1.0-SNAPSHOT
- renamed packages to io.cdap.plugin.failpipeline.sink